### PR TITLE
Näyttää ruokailuajat luettavammin

### DIFF
--- a/eljuja/templates/myynti.html
+++ b/eljuja/templates/myynti.html
@@ -13,19 +13,19 @@
 
         <!-- Näytetää radiovalinnat ja niiden viereen yhteenlasketut henkilömäärät kuhunkin ruokailuajankohtaan -->
         <label>
-            <input type="radio" name="aika" value="1630" required> 1630   ---    {{ passit_per_aika.1630 }} hlöä
+            <input type="radio" name="aika" value="1630" required> 16.30   ---    {{ passit_per_aika.1630 }} hlöä
         </label><br>
 
         <label>
-            <input type="radio" name="aika" value="1700" required> 1700   ---    {{ passit_per_aika.1700 }} hlöä
+            <input type="radio" name="aika" value="1700" required> 17.00   ---    {{ passit_per_aika.1700 }} hlöä
         </label><br>
 
         <label>
-            <input type="radio" name="aika" value="1730" required> 1730   ---   {{ passit_per_aika.1730 }} hlöä
+            <input type="radio" name="aika" value="1730" required> 17.30   ---   {{ passit_per_aika.1730 }} hlöä
         </label><br>
 
         <label>
-            <input type="radio" name="aika" value="1800" required> 1800  ---  {{ passit_per_aika.1800 }} hlöä
+            <input type="radio" name="aika" value="1800" required> 18.00  ---  {{ passit_per_aika.1800 }} hlöä
         </label><br>
 
 


### PR DESCRIPTION
Erottaa myyntisivulla ruokailuaikojen tunnit ja minuutit luettavammin pisteellä, vaikka koodissa pitääkin olla ilman pistettä.